### PR TITLE
Removed 1.9.3 from build-ruby

### DIFF
--- a/sample/build-ruby
+++ b/sample/build-ruby
@@ -59,7 +59,6 @@ ChkBuild::Ruby.def_target(
     '2.2',
     '2.1',
     '2.0.0',
-    '1.9.3',
   ],
 
 #   [ # :abi_check needs --enable-shared


### PR DESCRIPTION
1.9.3 is EOL now. We need to remove it from rubyci.