### PR TITLE
use single configuration and fix configuration usage

### DIFF
--- a/chkbuild/ruby.rb
+++ b/chkbuild/ruby.rb
@@ -597,11 +597,7 @@ def (ChkBuild::Ruby).build_proc(b)
       excludes = ["rubyspec/optional/ffi"]
       b.catch_error {
         FileUtils.rmtree "rubyspec_temp"
-        if ruby_version.before(1,9)
-          config = Dir.pwd + "/rubyspec/ruby.1.8.mspec"
-        else
-          config = Dir.pwd + "/rubyspec/ruby.1.9.mspec"
-        end
+        config = Dir.pwd + "/rubyspec/ruby.mspec"
         command = %W[bin/ruby mspec/bin/mspec -V -f s -B #{config} -t #{rubybin}]
         command << "rubyspec"
         command << {

--- a/chkbuild/ruby.rb
+++ b/chkbuild/ruby.rb
@@ -615,12 +615,8 @@ def (ChkBuild::Ruby).build_proc(b)
             next if !s.file?
             b.catch_error {
               FileUtils.rmtree "rubyspec_temp"
-              if ruby_version.before(1,9)
-                config = ruby_build_dir + "rubyspec/ruby.1.8.mspec"
-              else
-                config = ruby_build_dir + "rubyspec/ruby.1.9.mspec"
-              end
-              command = %W[bin/ruby mspec/bin/mspec -V -f s -B #{config} -t #{rubybin}]
+              config = ruby_build_dir + "rubyspec/ruby.mspec"
+              command = %W[bin/ruby mspec/bin/mspec -B #{config} -V -f s -t #{rubybin}]
               command << f.to_s
               command << {
                 :section=>f.to_s

--- a/chkbuild/ruby.rb
+++ b/chkbuild/ruby.rb
@@ -598,7 +598,7 @@ def (ChkBuild::Ruby).build_proc(b)
       b.catch_error {
         FileUtils.rmtree "rubyspec_temp"
         config = Dir.pwd + "/rubyspec/ruby.mspec"
-        command = %W[bin/ruby mspec/bin/mspec -V -f s -B #{config} -t #{rubybin}]
+        command = %W[bin/ruby mspec/bin/mspec -B #{config} -V -f s -t #{rubybin}]
         command << "rubyspec"
         command << {
           :section=>"rubyspec"


### PR DESCRIPTION
rubyspec unified to mspec configuration at https://github.com/ruby/rubyspec/commit/7a909e925c1baa9c700bd44af9241aef6e596714 .

I make to use this configuration with chkbuild. And, mspec has defect of configuration order. I move configuration option to first. Please see https://github.com/ruby/rubyspec/issues/38#issuecomment-75928406