### PR TITLE
Use the ruby.mspec config file for recent RubySpec.

### DIFF
--- a/chkbuild/ruby.rb
+++ b/chkbuild/ruby.rb
@@ -597,11 +597,7 @@ def (ChkBuild::Ruby).build_proc(b)
       excludes = ["rubyspec/optional/ffi"]
       b.catch_error {
         FileUtils.rmtree "rubyspec_temp"
-        if ruby_version.before(1,9)
-          config = Dir.pwd + "/rubyspec/ruby.1.8.mspec"
-        else
-          config = Dir.pwd + "/rubyspec/ruby.1.9.mspec"
-        end
+        config = Dir.pwd + "/rubyspec/ruby.mspec"
         command = %W[bin/ruby mspec/bin/mspec -V -f s -B #{config} -t #{rubybin}]
         command << "rubyspec"
         command << {
@@ -619,11 +615,7 @@ def (ChkBuild::Ruby).build_proc(b)
             next if !s.file?
             b.catch_error {
               FileUtils.rmtree "rubyspec_temp"
-              if ruby_version.before(1,9)
-                config = ruby_build_dir + "rubyspec/ruby.1.8.mspec"
-              else
-                config = ruby_build_dir + "rubyspec/ruby.1.9.mspec"
-              end
+              config = ruby_build_dir + "rubyspec/ruby.mspec"
               command = %W[bin/ruby mspec/bin/mspec -V -f s -B #{config} -t #{rubybin}]
               command << f.to_s
               command << {


### PR DESCRIPTION
* See https://github.com/ruby/rubyspec/commit/7a909e925c1baa9c700bd44af9241aef6e596714
  and https://github.com/ruby/rubyspec/commit/c750ce7b6d876ac21bdf477104072fea5331a697

Importantly, ruby.1.9.mspec does not exist in recent rubyspec since 1.9.3 support is dropped.