### PR TITLE
Support Ruby 2.4's version.h

### DIFF
--- a/chkbuild/ruby.rb
+++ b/chkbuild/ruby.rb
@@ -344,6 +344,12 @@ def (ChkBuild::Ruby).build_proc(b)
       end
     }
   end
+  if /\A\d+-\d+-\d+\z/ !~ version_info['RUBY_RELEASE_DATE']
+    version_info['RUBY_RELEASE_DATE'] = '%04d-%02d-%02d' % version_info.values_at(
+      *%w[YEAR MONTH DAY].map{|s|"RUBY_RELEASE_#{s}"}
+    ).map(&:to_i)
+    puts %<#define RUBY_RELEASE_DATE "#{version_info['RUBY_RELEASE_DATE']}">
+  end
   ruby_version = ChkBuild::Ruby::RubyVersion.new(version_info)
 
   if force_gperf


### PR DESCRIPTION
On Ruby 2.4 version.h defines RUBY_RELEASE_DATE as
RUBY_RELEASE_YEAR_STR"-"RUBY_RELEASE_MONTH_STR"-"RUBY_RELEASE_DAY_STR
which doesn't match `reldate = /^#\s*define RUBY_RELEASE_DATE "(\S+)"/.match(log)`